### PR TITLE
Add support for Markdown macro in ADF conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,14 +123,14 @@ Revenue|$50K|+25%
 ```
 ```
 
-5. **Importing External CSV Files**:
+6. **Importing External CSV Files**:
 ```markdown
 # Monthly Report
 
 ![Monthly Data](data/monthly-stats.csv)
 ```
 
-6. **Using YAML Front Matter for Metadata**:
+7. **Using YAML Front Matter for Metadata**:
 ```markdown
 ---
 title: "Team Documentation"
@@ -139,6 +139,8 @@ parentId: "123456"
 labels:
   - documentation
   - team
+useMarkdownMacro: true
+generateToc: true
 ---
 
 # Team Documentation
@@ -503,6 +505,8 @@ labels:
   - documentation
   - example
   - markdown
+useMarkdownMacro: true
+generateToc: true
 ---
 
 # Content starts here
@@ -512,13 +516,15 @@ Regular markdown content...
 
 Available front matter options:
 
-| Option     | Description                           |
-| ---------- | ------------------------------------- |
-| `title`    | The title of the page in Confluence   |
-| `space`    | The key of the Confluence space       |
-| `parentId` | The ID of the parent page             |
-| `pageId`   | The ID of an existing page to update  |
-| `labels`   | An array of labels to add to the page |
+| Option             | Description                                                   |
+| ------------------ | ------------------------------------------------------------- |
+| `title`            | The title of the page in Confluence                           |
+| `space`            | The key of the Confluence space                               |
+| `parentId`         | The ID of the parent page                                     |
+| `pageId`           | The ID of an existing page to update                          |
+| `labels`           | An array of labels to add to the page                         |
+| `useMarkdownMacro` | If true, uses Markdown macro instead of converting to ADF     |
+| `generateToc`      | If true, generates a table of contents at the top of the page |
 
 Front matter values take precedence over command line options, except when you explicitly provide command line options.
 
@@ -529,3 +535,44 @@ doc2conf push docs/example.md
 # Override front matter title with command line option
 doc2conf push docs/example.md --title "New Title"
 ```
+
+## CLI Options
+
++### Global Options
+
++| Option             | Description                                    |
++| ------------------ | ---------------------------------------------- |
++| `--debug`          | Enable debug mode with detailed logging        |
++| `--help`, `-h`     | Display help information                       |
++| `--version`, `-v`  | Display version information                    |
+
++### Convert Command Options
+
++| Option                  | Description                                              |
++| ----------------------- | -------------------------------------------------------- |
++| `-o, --output <file>`   | Output file path                                         |
++| `-f, --format <format>` | Input format (markdown, asciidoc, csv)                   |
++| `--toc`                 | Generate table of contents                               |
++| `--inline-cards`        | Parse inline cards                                       |
++| `--upload-images`       | Upload images to Confluence                              |
++| `--use-official-schema` | Validate against official ADF schema                     |
++| `--dry-run`             | Preview ADF output without saving                        |
++| `--instance-type <type>`| Confluence instance type (cloud or server)               |
++| `--use-markdown-macro`  | Use Markdown macro instead of converting to ADF          |
+
++### Push Command Options
+
++| Option                  | Description                                              |
++| ----------------------- | -------------------------------------------------------- |
++| `-s, --space <key>`     | Confluence space key                                     |
++| `-p, --parent <id>`     | Parent page ID                                           |
++| `-t, --title <title>`   | Page title                                               |
++| `-f, --format <format>` | Input format (markdown, asciidoc, csv)                   |
++| `--toc`                 | Generate table of contents                               |
++| `--inline-cards`        | Parse inline cards                                       |
++| `--upload-images`       | Upload images to Confluence                              |
++| `--use-official-schema` | Validate against official ADF schema                     |
++| `--instance-type <type>`| Confluence instance type (cloud or server)               |
++| `--use-markdown-macro`  | Use Markdown macro instead of converting to ADF          |
+
+## Environment Variables

--- a/src/__tests__/markdown-macro.test.ts
+++ b/src/__tests__/markdown-macro.test.ts
@@ -1,0 +1,49 @@
+import { Converter } from '../converter';
+
+describe('Markdown Macro', () => {
+  const converter = new Converter();
+
+  test('converts markdown to a document with a markdown macro', async () => {
+    const markdown = `# Test Heading
+
+This is a test paragraph.
+
+- List item 1
+- List item 2
+
+\`\`\`javascript
+function test() {
+  console.log('Hello, world!');
+}
+\`\`\`
+
+> This is a blockquote.
+
+| Column 1 | Column 2 |
+| -------- | -------- |
+| Value 1  | Value 2  |
+`;
+
+    const adf = await converter.convertToADF(markdown, { useMarkdownMacro: true });
+
+    // Check the ADF structure
+    expect(adf.type).toBe('doc');
+    expect(adf.version).toBe(1);
+    expect(adf.content?.length).toBe(1);
+
+    // Check that we have an extension node with the markdown macro
+    const macroNode = adf.content?.[0];
+    expect(macroNode?.type).toBe('extension');
+
+    // Check extension attributes with type assertion
+    const attrs = macroNode?.attrs as any;
+    expect(attrs?.extensionType).toBe('com.atlassian.confluence.macro.core');
+    expect(attrs?.extensionKey).toBe('markdown');
+    expect(attrs?.parameters?.macroParams).toBeDefined();
+
+    // Check that the text node contains the original markdown
+    const textNode = macroNode?.content?.[0];
+    expect(textNode?.type).toBe('text');
+    expect(textNode?.text).toBe(markdown.trim());
+  });
+});

--- a/src/__tests__/metadata.test.ts
+++ b/src/__tests__/metadata.test.ts
@@ -1,0 +1,45 @@
+import { parseMarkdownFile } from '../metadata';
+
+describe('Metadata Parser', () => {
+  test('parses YAML front matter with useMarkdownMacro option', () => {
+    const markdown = `---
+title: "Test Document"
+space: "TEST"
+parentId: "12345"
+labels:
+  - test
+  - example
+useMarkdownMacro: true
+---
+
+# Test Content
+
+This is test content.
+`;
+
+    const { content, metadata } = parseMarkdownFile(markdown);
+
+    // Check that the metadata was parsed correctly
+    expect(metadata.title).toBe('Test Document');
+    expect(metadata.space).toBe('TEST');
+    expect(metadata.parentId).toBe('12345');
+    expect(metadata.labels).toEqual(['test', 'example']);
+    expect(metadata.useMarkdownMacro).toBe(true);
+
+    // Check that the content was parsed correctly (without front matter)
+    expect(content.trim().startsWith('# Test Content')).toBe(true);
+  });
+
+  test('uses default value (false) for useMarkdownMacro when not specified', () => {
+    const markdown = `---
+title: "Test Document"
+space: "TEST"
+---
+
+# Test Content
+`;
+
+    const { metadata } = parseMarkdownFile(markdown);
+    expect(metadata.useMarkdownMacro).toBe(false);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,7 @@ interface ConvertOptions {
   title?: string;
   space?: string;
   parent?: string;
+  useMarkdownMacro?: boolean;
 }
 
 const program = new Command();
@@ -61,6 +62,7 @@ program
   .option('--use-official-schema', 'Validate against official ADF schema')
   .option('--dry-run', 'Preview ADF output without saving')
   .option('--instance-type <type>', 'Confluence instance type (cloud or server)', 'cloud')
+  .option('--use-markdown-macro', 'Use Markdown macro instead of converting to ADF')
   .action(async (file: string, options: ConvertOptions) => {
     try {
       // Set debug mode from global option
@@ -73,6 +75,7 @@ program
         uploadImages: options.uploadImages,
         useOfficialSchema: options.useOfficialSchema,
         instanceType: options.instanceType || 'cloud',
+        useMarkdownMacro: options.useMarkdownMacro,
       });
 
       if (options.dryRun) {
@@ -105,6 +108,7 @@ program
   .option('--upload-images', 'Upload images to Confluence')
   .option('--use-official-schema', 'Validate against official ADF schema')
   .option('--instance-type <type>', 'Confluence instance type (cloud or server)', 'cloud')
+  .option('--use-markdown-macro', 'Use Markdown macro instead of converting to ADF')
   .action(async (file: string, options: ConvertOptions) => {
     try {
       // Set debug mode from global option
@@ -138,6 +142,7 @@ program
         title?: string;
         pageId?: string;
         labels: string[];
+        useMarkdownMacro?: boolean;
       };
 
       const metadata: PushMetadata = {
@@ -146,6 +151,7 @@ program
         title: options.title,
         pageId: undefined,
         labels: [],
+        useMarkdownMacro: options.useMarkdownMacro,
       };
 
       let adf: ADFEntity;
@@ -181,6 +187,11 @@ program
             metadata.title = options.title || frontMatterMetadata.title;
             metadata.pageId = frontMatterMetadata.pageId; // No command line option for pageId
             metadata.labels = frontMatterMetadata.labels || [];
+            // Command line option has priority, then front matter
+            metadata.useMarkdownMacro =
+              options.useMarkdownMacro !== undefined
+                ? options.useMarkdownMacro
+                : frontMatterMetadata.useMarkdownMacro;
           }
         }
 
@@ -190,6 +201,7 @@ program
           parseInlineCards: options.inlineCards,
           uploadImages: options.uploadImages,
           useOfficialSchema: options.useOfficialSchema,
+          useMarkdownMacro: metadata.useMarkdownMacro,
         });
       }
 

--- a/src/formats/index.ts
+++ b/src/formats/index.ts
@@ -14,8 +14,14 @@ export interface ADFEntity {
 
 export type InputFormat = 'markdown' | 'asciidoc' | 'csv';
 
+// Extend ConversionOptions to ensure useMarkdownMacro is included
+export interface ExtendedConversionOptions extends ConversionOptions {
+  useMarkdownMacro?: boolean;
+  format?: string;
+}
+
 export interface FormatConverter {
-  convert(content: string, options: ConversionOptions): Promise<ADFEntity>;
+  convert(content: string, options: ExtendedConversionOptions): Promise<ADFEntity>;
 }
 
 export class AsciiDocConverter implements FormatConverter {
@@ -25,7 +31,7 @@ export class AsciiDocConverter implements FormatConverter {
     this.asciidoctor = asciidoctor();
   }
 
-  async convert(content: string, options: ConversionOptions): Promise<ADFEntity> {
+  async convert(content: string, options: ExtendedConversionOptions): Promise<ADFEntity> {
     const html = (
       this.asciidoctor as { convert: (content: string, options: Record<string, unknown>) => string }
     ).convert(content, {
@@ -46,7 +52,7 @@ export class AsciiDocConverter implements FormatConverter {
 }
 
 export class CsvConverter implements FormatConverter {
-  async convert(content: string, options: ConversionOptions): Promise<ADFEntity> {
+  async convert(content: string, options: ExtendedConversionOptions): Promise<ADFEntity> {
     return new Promise((resolve, reject) => {
       // If content is empty or whitespace only, return empty table
       if (!content || content.trim() === '') {
@@ -160,7 +166,7 @@ export class MarkdownConverter implements FormatConverter {
     this.converter = new Converter();
   }
 
-  async convert(content: string, options: ConversionOptions): Promise<ADFEntity> {
+  async convert(content: string, options: ExtendedConversionOptions): Promise<ADFEntity> {
     // Parse front matter metadata
     const { content: mdContent, metadata } = parseMarkdownFile(content);
 
@@ -192,7 +198,7 @@ export async function getConverter(format: InputFormat): Promise<FormatConverter
 export async function convertFile(
   filePath: string,
   format: InputFormat,
-  options: ConversionOptions
+  options: ExtendedConversionOptions
 ): Promise<ADFEntity> {
   const content = await fs.readFile(filePath, 'utf-8');
   const converter = await getConverter(format);

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -6,6 +6,7 @@ export interface ConfluenceMetadata {
   parentId?: string;
   pageId?: string;
   labels?: string[];
+  useMarkdownMacro?: boolean;
 }
 
 export interface ParsedMarkdown {
@@ -22,6 +23,7 @@ export function parseMarkdownFile(content: string): ParsedMarkdown {
     parentId: data.confluence?.parentId || data.parentId,
     pageId: data.confluence?.pageId || data.pageId,
     labels: data.confluence?.labels || data.labels || [],
+    useMarkdownMacro: data.confluence?.useMarkdownMacro || data.useMarkdownMacro || false,
   };
 
   return {
@@ -41,5 +43,6 @@ export function validateMetadata(
     title: metadata.title,
     pageId: metadata.pageId,
     labels: metadata.labels,
+    useMarkdownMacro: metadata.useMarkdownMacro,
   };
 }


### PR DESCRIPTION
- Introduced `useMarkdownMacro` option in CLI and conversion interfaces to enable wrapping markdown content in a Markdown macro.
- Enhanced `Converter` class to create ADF documents with Markdown macros when the option is enabled.
- Updated `ConfluenceClient` to handle Markdown macro content correctly during page creation and updates.
- Added tests to validate the conversion of markdown to ADF with the Markdown macro and ensure proper metadata parsing.
- Refactored related components to support the new functionality and maintain consistency across the codebase.